### PR TITLE
Firefox default search to Google

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -21,7 +21,7 @@
       "ath": "<a class='button' href='/firefox-privacy-config'>Harden Firefox</a>",
       "infoa": "5.1% of total desktop browser market share in 2021",
       "infob": "Forked from the now defunct Mozilla browser in 2004",
-      "search": "DuckDuckGo"
+      "search": "Google"
     },
     {
       "id": "2",


### PR DESCRIPTION
Change Firefox's default search provider from DuckDuckGo to Google